### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,13 +15,13 @@ attach	KEYWORD2
 detach	KEYWORD2
 write	KEYWORD2
 read	KEYWORD2
-stop    KEYWORD2
+stop	KEYWORD2
 attached	KEYWORD2
 writeMicroseconds	KEYWORD2
 readMicroseconds	KEYWORD2
 slowmove	KEYWORD2
-sequencePlay KEYWORD2
-sequenceStop KEYWORD2
+sequencePlay	KEYWORD2
+sequenceStop	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords